### PR TITLE
ImageNet: make preprocessed,full depend on original,full

### DIFF
--- a/package/dataset-imagenet-preprocessed-using-opencv/.cm/meta.json
+++ b/package/dataset-imagenet-preprocessed-using-opencv/.cm/meta.json
@@ -4,10 +4,9 @@
     "install_env": {
       "CK_IMAGE_FILE": "",
       "PACKAGE_VERSION": "2012",
-
       "_SUBSET_FOF": "image_list.txt",
       "_SUBSET_OFFSET": "0",
-      "_SUBSET_VOLUME": ""
+      "_SUBSET_VOLUME": "500"
     },
     "soft_uoa": "dataset.imagenet.preprocessed",
     "no_os_in_suggested_path": "yes",
@@ -26,7 +25,14 @@
       "local": "yes",
       "name": "ImageNet dataset (original)",
       "sort": 10,
-      "tags": "dataset,imagenet,original"
+      "tags": "dataset,imagenet,original",
+      "update_tags_if_env": {
+        "full": [
+          {
+            "_SUBSET_VOLUME": "50000"
+          }
+        ]
+      }
     },
     "lib-python-numpy": {
       "local": "yes",
@@ -129,7 +135,7 @@
       },
       "extra_env": {
         "_SUBSET_OFFSET": "0",
-        "_SUBSET_VOLUME": ""
+        "_SUBSET_VOLUME": "1"
       }
     },
     "first.20": {
@@ -142,22 +148,22 @@
         "_SUBSET_VOLUME": "20"
       }
     },
+    "first.500": {
+      "extra_customize": {
+        "package_extra_name": " (first 500)"
+      },
+      "extra_env": {
+        "_SUBSET_OFFSET": "0",
+        "_SUBSET_VOLUME": "500"
+      }
+    },
     "full": {
       "extra_customize": {
         "package_extra_name": " (full)"
       },
       "extra_env": {
         "_SUBSET_OFFSET": "0",
-        "_SUBSET_VOLUME": ""
-      }
-    },
-    "last.20": {
-      "extra_customize": {
-        "package_extra_name": " (last 20)"
-      },
-      "extra_env": {
-        "_SUBSET_OFFSET": "-20",
-        "_SUBSET_VOLUME": ""
+        "_SUBSET_VOLUME": "50000"
       }
     },
     "side.96": {

--- a/package/dataset-imagenet-preprocessed-using-opencv/preprocess_image_dataset.py
+++ b/package/dataset-imagenet-preprocessed-using-opencv/preprocess_image_dataset.py
@@ -121,7 +121,7 @@ if __name__ == '__main__':
     convert_to_bgr          = os.getenv('_CONVERT_TO_BGR', '').lower() in ('yes', 'true', 'on', '1')
     audit_test03            = os.getenv('_AUDIT_TEST03', '').lower() in ('yes', 'true', 'on', '1')
     offset                  = int( os.getenv('_SUBSET_OFFSET', 0) )
-    volume_str              = os.getenv('_SUBSET_VOLUME', '' )
+    volume                  = int( os.environ['_SUBSET_VOLUME'] )
     fof_name                = os.getenv('_SUBSET_FOF', '')
     data_type               = os.getenv('_DATA_TYPE', '')
     new_file_extension      = os.getenv('_NEW_EXTENSION', '')
@@ -137,7 +137,7 @@ if __name__ == '__main__':
 
     print(("From: {} , To: {} , Size: {} , Crop: {} , InterSize: {} , 2BGR: {}, AUD: {}, OFF: {}, VOL: '{}', FOF: {},"+
         " DTYPE: {}, EXT: {}, NORM: {}, SMEAN: {}, GCM: {}, INTER: {}, IMG: {}").format(
-        source_dir, destination_dir, square_side, crop_percentage, inter_size, convert_to_bgr, audit_test03, offset, volume_str, fof_name,
+        source_dir, destination_dir, square_side, crop_percentage, inter_size, convert_to_bgr, audit_test03, offset, volume, fof_name,
         data_type, new_file_extension, normalize_data, subtract_mean, given_channel_means, interpolation_method, image_file) )
 
     if interpolation_method == 'INTER_AREA':
@@ -159,10 +159,9 @@ if __name__ == '__main__':
         if offset<0:        # support offsets "from the right"
             offset += total_volume
 
-        volume = int(volume_str) if len(volume_str)>0 else total_volume-offset
-
         selected_filenames = sorted_filenames[offset:offset+volume]
 
+    assert len(selected_filenames) == volume
 
     output_filenames = preprocess_files(
         selected_filenames, source_dir, destination_dir, crop_percentage, square_side, inter_size, convert_to_bgr, audit_test03,

--- a/package/dataset-imagenet-preprocessed-using-pillow/.cm/meta.json
+++ b/package/dataset-imagenet-preprocessed-using-pillow/.cm/meta.json
@@ -5,7 +5,7 @@
         "_INPUT_SQUARE_SIDE": "224",
         "_CROP_FACTOR": "87.5",
         "_SUBSET_OFFSET": "0",
-        "_SUBSET_VOLUME": "",
+        "_SUBSET_VOLUME": "500",
         "_SUBSET_FOF": "image_list.txt",
         "_NEW_EXTENSION": "rgb8",
         "_DATA_TYPE": "uint8",
@@ -24,7 +24,14 @@
       "local": "yes", 
       "name": "ImageNet dataset (original)",
       "sort": 10, 
-      "tags": "dataset,imagenet,original"
+      "tags": "dataset,imagenet,original",
+      "update_tags_if_env": {
+        "full": [
+          {
+            "_SUBSET_VOLUME": "50000"
+          }
+        ]
+      }
     },
     "python": {
       "local": "yes",
@@ -64,7 +71,7 @@
     "external_file": {
       "extra_env": {
         "_SUBSET_OFFSET": "0",
-        "_SUBSET_VOLUME": ""
+        "_SUBSET_VOLUME": "1"
       },
       "extra_customize": {
         "package_name": "Pre-processed single image ($<<CK_IMAGE_FILE>>$)"
@@ -134,19 +141,10 @@
         "package_extra_name": " (first 20)"
       }
     },
-    "last.20": {
-      "extra_env": {
-        "_SUBSET_OFFSET": "-20",
-        "_SUBSET_VOLUME": ""
-      },
-      "extra_customize": {
-        "package_extra_name": " (last 20)"
-      }
-    },
     "full": {
       "extra_env": {
         "_SUBSET_OFFSET": "0",
-        "_SUBSET_VOLUME": ""
+        "_SUBSET_VOLUME": "5000000"
       },
       "extra_customize": {
         "package_extra_name": " (full)"

--- a/package/dataset-imagenet-preprocessed-using-pillow/preprocess_image_dataset.py
+++ b/package/dataset-imagenet-preprocessed-using-pillow/preprocess_image_dataset.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
     inter_size              = int( os.getenv('_INTERMEDIATE_SIZE', 0) )
     convert_to_bgr          = os.getenv('_CONVERT_TO_BGR', '').lower() == 'yes'
     offset                  = int( os.getenv('_SUBSET_OFFSET', 0) )
-    volume_str              = os.getenv('_SUBSET_VOLUME', '' )
+    volume                  = int( os.environ['_SUBSET_VOLUME'] )
     fof_name                = os.getenv('_SUBSET_FOF', 'fof.txt')
     data_type               = os.getenv('_DATA_TYPE', 'uint8')
     new_file_extension      = os.getenv('_NEW_EXTENSION', '')
@@ -132,10 +132,9 @@ if __name__ == '__main__':
         if offset<0:        # support offsets "from the right"
             offset += total_volume
 
-        volume = int(volume_str) if len(volume_str)>0 else total_volume-offset
-
         selected_filenames = sorted_filenames[offset:offset+volume]
 
+    assert len(selected_filenames) == volume
 
     output_filenames = preprocess_files(selected_filenames, source_dir, destination_dir, crop_percentage, square_side, inter_size, convert_to_bgr, data_type, new_file_extension)
 

--- a/package/dataset-imagenet-preprocessed-using-tensorflow/.cm/meta.json
+++ b/package/dataset-imagenet-preprocessed-using-tensorflow/.cm/meta.json
@@ -9,7 +9,7 @@
       "_NEW_EXTENSION": "rgbf32",
       "_SUBSET_FOF": "image_list.txt",
       "_SUBSET_OFFSET": "0",
-      "_SUBSET_VOLUME": ""
+      "_SUBSET_VOLUME": "500"
     },
     "no_os_in_suggested_path": "yes",
     "no_ver_in_suggested_path": "yes",
@@ -77,7 +77,7 @@
       },
       "extra_env": {
         "_SUBSET_OFFSET": "0",
-        "_SUBSET_VOLUME": ""
+        "_SUBSET_VOLUME": "1"
       }
     },
     "first.20": {
@@ -104,16 +104,7 @@
       },
       "extra_env": {
         "_SUBSET_OFFSET": "0",
-        "_SUBSET_VOLUME": ""
-      }
-    },
-    "last.20": {
-      "extra_customize": {
-        "package_extra_name": " (last 20)"
-      },
-      "extra_env": {
-        "_SUBSET_OFFSET": "-20",
-        "_SUBSET_VOLUME": ""
+        "_SUBSET_VOLUME": "50000"
       }
     },
     "side.224": {

--- a/package/dataset-imagenet-preprocessed-using-tensorflow/preprocess_image_dataset_using_tensorflow.py
+++ b/package/dataset-imagenet-preprocessed-using-tensorflow/preprocess_image_dataset_using_tensorflow.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
 
     square_side             = int( os.environ['_INPUT_SQUARE_SIDE'] )
     offset                  = int( os.getenv('_SUBSET_OFFSET', 0) )
-    volume_str              = os.getenv('_SUBSET_VOLUME', '' )
+    volume                  = int( os.environ['_SUBSET_VOLUME'] )
     fof_name                = os.getenv('_SUBSET_FOF', 'fof.txt')
     data_type               = os.getenv('_DATA_TYPE', 'uint8')
     new_file_extension      = os.getenv('_NEW_EXTENSION', '')
@@ -78,10 +78,9 @@ if __name__ == '__main__':
         if offset<0:        # support offsets "from the right"
             offset += total_volume
 
-        volume = int(volume_str) if len(volume_str)>0 else total_volume-offset
-
         selected_filenames = sorted_filenames[offset:offset+volume]
 
+    assert len(selected_filenames) == volume
 
     output_filenames = preprocess_files(selected_filenames, source_dir, destination_dir, square_side, data_type, new_file_extension)
 


### PR DESCRIPTION
* Make `dataset,imagenet,preprocessed,full` depend on `dataset,imagenet,original,full`.
* Remove `last.20` variations as not reliable (last 20 of 500 and last 20 of 50000 are not the same).
* `preprocess_image_*.py` scripts: add additional check to make sure that there are exactly `_SUBSET_VOLUME` images.